### PR TITLE
Add RPC notifications for the glob tool

### DIFF
--- a/ui/src/components/App.tsx
+++ b/ui/src/components/App.tsx
@@ -93,6 +93,8 @@ const App: React.FC<AppProps> = ({ backend }) => {
                       description:
                         execution.message ||
                         (execution.metadata.description as string | undefined),
+                      // Pass through the full metadata to ensure pattern is available
+                      metadata: execution.metadata,
                     },
                   },
                 ],
@@ -263,6 +265,12 @@ const App: React.FC<AppProps> = ({ backend }) => {
                 file_path: params.file_path,
                 lines: params.lines,
                 description: params.description,
+                metadata: {
+                  file_path: params.file_path,
+                  lines: params.lines,
+                  description: params.description,
+                  pattern: params.pattern,
+                },
               },
             },
           ],

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -24,6 +24,7 @@ export interface ToolData {
   file_path?: string;
   lines?: number;
   description?: string;
+  metadata?: Record<string, unknown>;
 }
 
 // Tool execution interface


### PR DESCRIPTION
# PR Type
Feature

# Short Description
- Adds RPC notifications for GlobTool
- Fixes the glob tool use, just has pattern now and not path since the tool can always encode the path in the pattern
- Fixed UI to read the RPC notifications to display tool status
